### PR TITLE
Use the UTC formatter so that the ICS times are correctly transferred…

### DIFF
--- a/application/libraries/Ics_file.php
+++ b/application/libraries/Ics_file.php
@@ -177,6 +177,7 @@ class Ics_file
 
         // Setup exporter.
         $calendarExport = new CalendarExport(new CalendarStream(), new Formatter());
+        $calendarExport->setDateTimeFormat('utc');
         $calendarExport->addCalendar($calendar);
 
         return $calendarExport->getStream();
@@ -219,6 +220,7 @@ class Ics_file
 
         // Setup exporter.
         $calendarExport = new CalendarExport(new CalendarStream(), new Formatter());
+        $calendarExport->setDateTimeFormat('utc');
         $calendarExport->addCalendar($calendar);
 
         return $calendarExport->getStream();


### PR DESCRIPTION
… to remote calendars